### PR TITLE
bugfix: typo causing invalid response

### DIFF
--- a/src/api/NB_Single.php
+++ b/src/api/NB_Single.php
@@ -92,7 +92,7 @@ class NB_Single
                     return true;
                 }
 
-                if (is_numeric($type) && $types == $this->response->result) {
+                if (is_numeric($type) && $type == $this->response->result) {
                     return true;
                 }
             }


### PR DESCRIPTION
This is a quick fix. There was a typo in the code which triggered an invalid response on vaild email accounts.
