### PR TITLE
Fix typo in "catchall" constant

### DIFF
--- a/src/api/NB_Single.php
+++ b/src/api/NB_Single.php
@@ -27,6 +27,12 @@ class NB_Single
     /**
      * Value of a catchall email
      */
+    const CATCHALL = 3;
+
+    /**
+     * Value of a catchall email.
+     * @deprecated Original version with typo.  Retained for backwards compatability.
+     */
     const CATACHALL = 3;
 
     /**
@@ -45,7 +51,7 @@ class NB_Single
         'invalid' => self::BAD,
         'bad' => self::BAD, // Alias
         'disposable' => self::DISPOSABLE,
-        'catchall' => self::CATACHALL,
+        'catchall' => self::CATCHALL,
         'unknown' => self::UNKNOWN,
     ];
 
@@ -58,7 +64,7 @@ class NB_Single
         self::GOOD => 'Valid',
         self::BAD => 'Invalid',
         self::DISPOSABLE => 'Disposable',
-        self::CATACHALL => 'Catchall',
+        self::CATCHALL => 'Catchall',
         self::UNKNOWN => 'Unknown',
     ];
 


### PR DESCRIPTION
The original API has "catchall" spelled as "CATACHALL" in the constants in NB_Single.  This corrects the typo, but also retains the original constant to maintain compatibility as removing a constant would cause an E_ERROR for anyone who hasn't updated.

Feel free to remove the old definition if that isn't a concern.