### PR TITLE
Add response validation before parsing.

### DIFF
--- a/src/Object/VerificationObject.php
+++ b/src/Object/VerificationObject.php
@@ -1,5 +1,7 @@
 <?php namespace NeverBounce\Object;
 
+use NeverBounce\Errors\GeneralException;
+
 class VerificationObject extends ResponseObject
 {
 
@@ -26,9 +28,12 @@ class VerificationObject extends ResponseObject
      * Verification constructor.
      * @param string $email
      * @param array $response
+     * @throws GeneralException
      */
     public function __construct($email, $response)
     {
+        $this->validateResponse($response);
+
         $response['email'] = $email;
         $response['result_integer'] = self::$integerCodes[$response['result']];
         $response['credits_info'] = new ResponseObject(
@@ -38,6 +43,23 @@ class VerificationObject extends ResponseObject
             isset($response['address_info']) ? $response['address_info'] : []
         );
         parent::__construct($response);
+    }
+
+    /**
+     * @param mixed $response
+     *
+     * @throws GeneralException
+     */
+    private function validateResponse($response)
+    {
+        if (!is_array($response)) {
+            $exceptionMessage = sprintf(
+                'Invalid server response. Array is expected instance of \'%s\' given',
+                gettype($response)
+            );
+
+            throw new GeneralException($exceptionMessage);
+        }
     }
 
     /**

--- a/tests/Objects/VerificationObjectTest.php
+++ b/tests/Objects/VerificationObjectTest.php
@@ -1,6 +1,8 @@
 <?php namespace NeverBounce;
 
+use NeverBounce\Errors\GeneralException;
 use NeverBounce\Object\VerificationObject;
+use Exception;
 
 class VerificationObjectTest extends \PHPUnit_Framework_TestCase
 {
@@ -120,5 +122,26 @@ class VerificationObjectTest extends \PHPUnit_Framework_TestCase
             VerificationObject::DISPOSABLE,
         ]));
         $this->assertFalse($valid->not([VerificationObject::VALID]));
+    }
+
+    public function testInvalidResponseHandling()
+    {
+        $response = <<<HTML
+<html>
+<head><title>502 Bad Gateway</title></head>
+<body bgcolor="white">
+<center><h1>502 Bad Gateway</h1></center>
+<hr><center>nginx/1.10.3 (Ubuntu)</center>
+</body>
+</html>
+HTML;
+
+        try {
+            new VerificationObject('valid@neverbounce.com', $response);
+        } catch (Exception $exception) {
+            $this->assertInstanceOf(GeneralException::class, $exception);
+            $expectedMessage = 'Invalid server response. Array is expected instance of \'string\' given';
+            $this->assertEquals($expectedMessage, $exception->getMessage());
+        }
     }
 }


### PR DESCRIPTION
Sometimes endpoint returns a html response, for example:

```html
<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
```
And there's no way to handle this case.