### PR TITLE
Added support for "inconclusive" result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "neverbounce/neverbounce-php",
+    "name": "ineventapp/neverbounce-php",
     "description": "This package provides convenient methods to integrate the NeverBounce API into your project.",
     "keywords": ["email", "validation", "verification", "email validation"],
     "homepage": "https://neverbounce.com",

--- a/src/Object/VerificationObject.php
+++ b/src/Object/VerificationObject.php
@@ -20,16 +20,18 @@ class VerificationObject extends ResponseObject
     const DISPOSABLE = 2;
     const CATCHALL = 3;
     const UNKNOWN = 4;
+    const INCONCLUSIVE = 4;
 
     /**
      * @var array
      */
     protected static $integerCodes = [
-        'valid'      => self::VALID,
-        'invalid'    => self::INVALID,
-        'disposable' => self::DISPOSABLE,
-        'catchall'   => self::CATCHALL,
-        'unknown'    => self::UNKNOWN,
+        'valid'        => self::VALID,
+        'invalid'      => self::INVALID,
+        'disposable'   => self::DISPOSABLE,
+        'catchall'     => self::CATCHALL,
+        'unknown'      => self::UNKNOWN,
+        'inconclusive' => self::INCONCLUSIVE
     ];
 
     /**
@@ -40,7 +42,11 @@ class VerificationObject extends ResponseObject
     public function __construct($email, $response)
     {
         $response['email'] = $email;
-        $response['result_integer'] = self::$integerCodes[$response['result']];
+        if (isset(self::$integerCodes[$response['result']])) {
+            $response['result_integer'] = self::$integerCodes[$response['result']];
+        } else {
+            $response['result_integer'] = self::UNKNOWN;
+        }
         $response['credits_info'] = new ResponseObject(
             isset($response['credits_info']) ? $response['credits_info'] : []
         );


### PR DESCRIPTION
It seems there is a new status type called `inconclusive` and the SDK is not prepared to handle this case scenario.

```
Fatal error #8 on line 43 in file /var/www/html/InEvent/vendor/neverbounce/neverbounce-php/src/Object/VerificationObject.php
Message: 'Undefined index: inconclusive'
```