### PR TITLE
Correct Job class method PHPDoc data types

### DIFF
--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -28,7 +28,7 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $jobId
+     * @param int $jobId
      * @return ResponseObject
      * @throws \NeverBounce\Errors\ThrottleException
      * @throws \NeverBounce\Errors\HttpClientException
@@ -102,8 +102,8 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $jobId
-     * @param bool $autostart
+     * @param int   $jobId
+     * @param bool  $autostart
      * @return ResponseObject
      * @throws \NeverBounce\Errors\ThrottleException
      * @throws \NeverBounce\Errors\HttpClientException
@@ -122,9 +122,9 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $jobId
-     * @param bool   $runsample
-     * @param bool $allowManualReview
+     * @param int   $jobId
+     * @param bool  $runsample
+     * @param bool  $allowManualReview
      * @return ResponseObject
      * @throws \NeverBounce\Errors\ThrottleException
      * @throws \NeverBounce\Errors\HttpClientException
@@ -144,7 +144,7 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $jobId
+     * @param int    $jobId
      * @param array  $query
      * @return string
      * @throws \NeverBounce\Errors\ThrottleException
@@ -164,7 +164,7 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $jobId
+     * @param int    $jobId
      * @param array  $query
      * @return ResponseObject
      * @throws \NeverBounce\Errors\ThrottleException

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -44,15 +44,16 @@ class Jobs extends ApiClient
     }
 
     /**
-     * @param string $input
-     * @param string $inputlocation
-     * @param bool   $runsample
-     * @param bool   $autoparse
-     * @param bool   $autostart
-     * @param bool|null $historicalData
-     * @param bool   $allowManualReview
-     * @param string $callbackUrl
-     * @param array  $callbackHeaders
+     * @param string|array $input
+     * @param string       $inputlocation
+     * @param bool|null    $runsample
+     * @param bool|null    $autoparse
+     * @param bool|null    $autostart
+     * @param bool|null    $historicalData
+     * @param bool|null    $allowManualReview
+     * @param string|null  $callbackUrl
+     * @param array|null   $callbackHeaders
+     *
      * @return ResponseObject
      * @throws \NeverBounce\Errors\ThrottleException
      * @throws \NeverBounce\Errors\HttpClientException


### PR DESCRIPTION
1. Correct PHPDoc of Jobs class create method
The PHPDoc data types of Jobs class "create" method arguments are
fixed:
- $input argument can be as "string" type when creating a job from
file URL, also an "array" type when creating job from supplied data.
- $runsample, $autoparse, $autostart, $allowManualReview, $callbackUrl,
$callbackHeaders arguments' PHPDocs are fixed to mention they are
nullable arguments.
2. Correct PHPDoc $jobId arg in Job class methods
As mentioned in API documentation the job id is an `int32` type
value, and so in PHP it is more correct to specify its data type as
`int` and not `string`. So appropriate corrections are done in Job
class methods receiving $jobId argument.